### PR TITLE
Fixed GET and PUT endpoints that was failing

### DIFF
--- a/Api/Rest/Findmefollow.php
+++ b/Api/Rest/Findmefollow.php
@@ -1,67 +1,61 @@
 <?php
 namespace FreePBX\modules\Findmefollow\Api\Rest;
+
 use FreePBX\modules\Api\Rest\Base;
+
 class Findmefollow extends Base {
-	protected $module = 'findmefollow';
-	public function setupRoutes($app) {
-		/**
-		* @verb GET
-		* @returns - a list of users' findmefollow settings
-		* @uri /findmefollow/users
-		*/
-		$app->get('/users', function ($request, $response, $args) {
-			\FreePBX::Modules()->loadFunctionsInc('findmefollow');
-			$findmefollow_allusers = findmefollow_allusers();
+    protected $module = 'findmefollow';
 
-			foreach ($findmefollow_allusers as $user) {
-				$users[$user[0]] = $user[1];
-				unset($user);
-			}
+    public function __construct($freepbx, $module) {
+        parent::__construct($freepbx, $module);
+        $this->freepbx->Modules->loadFunctionsInc($module);
+    }
 
-			$users = $users ? $users : false;
-			return $response->withJson($users);
-		})->add($this->checkAllReadScopeMiddleware());
 
-		/**
-		* @verb GET
-		 * @returns - a list of users' find me follow me settings
-		 * @uri /findmefollow/users/:id
-		 */
-		$app->get('/users/{id}', function ($request, $response, $args) {
-			\FreePBX::Modules()->loadFunctionsInc('findmefollow');
-			$users = findmefollow_get($args['id'], 1);
-			$users = $users ? $users : false;
-			return $response->withJson($users);
-		})->add($this->checkAllReadScopeMiddleware());
+    public function setupRoutes($app) {
+        /**
+         * @verb GET
+         * @returns - a list of users' findmefollow settings
+         * @uri /findmefollow/users
+         */
+        $app->get('/users', function ($request, $response, $args) {
+            $findmefollow_allusers = \findmefollow_allusers();
 
-		/**
-		* @verb PUT
-		* @uri /findmefollow/users/:id
-		*/
-		$app->put('/users/{id}', function ($request, $response, $args) {
-			\FreePBX::Modules()->loadFunctionsInc('findmefollow');
-			$params = $request->getParsedBody();
+            foreach ($findmefollow_allusers as $user) {
+                $users[$user[0]] = $user[1];
+                unset($user);
+            }
 
-			findmefollow_del($args['id']);
-			return $response->withJson(findmefollow_add(
-				$args['id'],
-				$params['strategy'],
-				$params['grptime'],
-				$params['grplist'],
-				$params['postdest'],
-				$params['grppre'],
-				$params['annmsg_id'],
-				$params['dring'],
-				$params['needsconf'],
-				$params['remotealert_id'],
-				$params['toolate_id'],
-				$params['ringing'],
-				$params['pre_ring'],
-				$params['ddial'],
-				$params['changecid'],
-				$params['fixedcid'])
-			);
+            $users = $users ? $users : false;
+            return $response->withJson($users);
+        })->add($this->checkAllReadScopeMiddleware());
 
-		})->add($this->checkAllWriteScopeMiddleware());
-	}
+        /**
+         * @verb GET
+         * @returns - a list of users' find me follow me settings
+         * @uri /findmefollow/users/:id
+         */
+        $app->get('/users/{id}', function ($request, $response, $args) {
+
+            $users = $this->freepbx->Findmefollow->get($args['id'], 1);
+
+            $users = $users ? $users : false;
+            return $response->withJson($users);
+        })->add($this->checkAllReadScopeMiddleware());
+
+        /**
+         * @verb PUT
+         * @uri /findmefollow/users/:id
+         */
+        $app->put('/users/{id}', function ($request, $response, $args) {
+            $params = $request->getParsedBody();
+
+            $this->freepbx->Findmefollow->del($args['id']);
+            return $response->withJson($this->freepbx->Findmefollow->add(
+                $args['id'],
+                $params)
+            );
+
+        })->add($this->checkAllWriteScopeMiddleware());
+    }
 }


### PR DESCRIPTION
I tried the latest version with FreePBX 15.0.17.34 and the GET and PUT endpoint on /users/{id} address was failing because of non-existing functions. I reworked API a little bit to the working state.

Tested with FreePBX of version 15.0.17.34 and works smoothly.